### PR TITLE
Please add cmd_vel Geometry Twist example from ROS1 unitree_ros_to_real back!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ include_directories(
 
 link_directories(${CMAKE_SOURCE_DIR}/unitree_legged_sdk-master/lib)
 
+add_executable(ros2_twist_sub src/ros2_twist_sub.cpp)
+target_link_libraries(ros2_twist_sub ${EXTRA_LIBS})
+ament_target_dependencies(ros2_twist_sub rclcpp ros2_unitree_legged_msgs)
+
 add_executable(ros2_udp src/ros2_udp.cpp)
 target_link_libraries(ros2_udp ${EXTRA_LIBS})
 ament_target_dependencies(ros2_udp rclcpp ros2_unitree_legged_msgs)
@@ -42,6 +46,7 @@ target_link_libraries(ros2_position_example ${EXTRA_LIBS})
 ament_target_dependencies(ros2_position_example rclcpp ros2_unitree_legged_msgs)
 
 install(TARGETS
+    ros2_twist_sub
     ros2_udp
     ros2_walk_example
     ros2_position_example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(rclcpp REQUIRED)
 
 find_package(ros2_unitree_legged_msgs REQUIRED)
 
-
 message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64.*")
   set(ARCH amd64)
@@ -20,18 +19,18 @@ set(EXTRA_LIBS -pthread libunitree_legged_sdk_${ARCH}.so lcm)
 
 set(CMAKE_CXX_FLAGS "-O3")
 
+message("-- PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
+message("-- CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
 include_directories(
     include
-    ${CMAKE_SOURCE_DIR}/unitree_legged_sdk-master/include
+    ${CMAKE_SOURCE_DIR}/../unitree_legged_sdk/include/
 )
 
-
-
-link_directories(${CMAKE_SOURCE_DIR}/unitree_legged_sdk-master/lib)
+link_directories(${CMAKE_SOURCE_DIR}/../unitree_legged_sdk/lib)
 
 add_executable(ros2_twist_sub src/ros2_twist_sub.cpp)
 target_link_libraries(ros2_twist_sub ${EXTRA_LIBS})
-ament_target_dependencies(ros2_twist_sub rclcpp ros2_unitree_legged_msgs)
+ament_target_dependencies(ros2_twist_sub rclcpp geometry_msgs std_msgs ros2_unitree_legged_msgs)
 
 add_executable(ros2_udp src/ros2_udp.cpp)
 target_link_libraries(ros2_udp ${EXTRA_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 find_package(ros2_unitree_legged_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64.*")

--- a/include/convert.h
+++ b/include/convert.h
@@ -301,13 +301,13 @@ ros2_unitree_legged_msgs::msg::HighState state2rosMsg(UNITREE_LEGGED_SDK::HighSt
     return ros_msg;
 }
 
-UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr &msg)
+UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr msg)
 {
     UNITREE_LEGGED_SDK::HighCmd cmd;
 
     cmd.head[0] = 0xFE;
     cmd.head[1] = 0xEF;
-    cmd.levelFlag = UNITREE_LEGGED_SDK::HIGHLEVEL;
+    cmd.levelFlag = 0;
     cmd.mode = 0;
     cmd.gaitType = 0;
     cmd.speedLevel = 0;
@@ -321,13 +321,14 @@ UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr
     cmd.yawSpeed = 0.0f;
     cmd.reserve = 0;
 
+/*
     cmd.velocity[0] = msg->linear.x;
     cmd.velocity[1] = msg->linear.y;
     cmd.yawSpeed = msg->angular.z;
 
+*/
     cmd.mode = 2;
     cmd.gaitType = 1;
-
     return cmd;
 }
 

--- a/include/convert.h
+++ b/include/convert.h
@@ -17,6 +17,7 @@ Use of this source code is governed by the MPL-2.0 license, see LICENSE.
 #include "ros2_unitree_legged_msgs/msg/imu.h"
 #include "unitree_legged_sdk/unitree_legged_sdk.h"
 #include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 
 UNITREE_LEGGED_SDK::BmsCmd rosMsg2Cmd(const ros2_unitree_legged_msgs::msg::BmsCmd &msg)
 {
@@ -298,6 +299,36 @@ ros2_unitree_legged_msgs::msg::HighState state2rosMsg(UNITREE_LEGGED_SDK::HighSt
     ros_msg.crc = state.crc;
 
     return ros_msg;
+}
+
+UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr &msg)
+{
+    UNITREE_LEGGED_SDK::HighCmd cmd;
+
+    cmd.head[0] = 0xFE;
+    cmd.head[1] = 0xEF;
+    cmd.levelFlag = UNITREE_LEGGED_SDK::HIGHLEVEL;
+    cmd.mode = 0;
+    cmd.gaitType = 0;
+    cmd.speedLevel = 0;
+    cmd.footRaiseHeight = 0;
+    cmd.bodyHeight = 0;
+    cmd.euler[0] = 0;
+    cmd.euler[1] = 0;
+    cmd.euler[2] = 0;
+    cmd.velocity[0] = 0.0f;
+    cmd.velocity[1] = 0.0f;
+    cmd.yawSpeed = 0.0f;
+    cmd.reserve = 0;
+
+    cmd.velocity[0] = msg->linear.x;
+    cmd.velocity[1] = msg->linear.y;
+    cmd.yawSpeed = msg->angular.z;
+
+    cmd.mode = 2;
+    cmd.gaitType = 1;
+
+    return cmd;
 }
 
 #endif // _CONVERT_H_

--- a/include/convert.h
+++ b/include/convert.h
@@ -301,7 +301,7 @@ ros2_unitree_legged_msgs::msg::HighState state2rosMsg(UNITREE_LEGGED_SDK::HighSt
     return ros_msg;
 }
 
-UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr msg)
+UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr &msg)
 {
     UNITREE_LEGGED_SDK::HighCmd cmd;
 
@@ -321,12 +321,10 @@ UNITREE_LEGGED_SDK::HighCmd rosMsg2Cmd(const geometry_msgs::msg::Twist::ConstPtr
     cmd.yawSpeed = 0.0f;
     cmd.reserve = 0;
 
-/*
     cmd.velocity[0] = msg->linear.x;
     cmd.velocity[1] = msg->linear.y;
     cmd.yawSpeed = msg->angular.z;
 
-*/
     cmd.mode = 2;
     cmd.gaitType = 1;
     return cmd;

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
     <build_depend>rcl</build_depend>
     <build_depend>std_msgs</build_depend>
+    <build_depend>geometry_msgs</build_depend>
     <build_export_depend>roscpp</build_export_depend>
     <build_export_depend>std_msgs</build_export_depend>
     <exec_depend>rcl</exec_depend>

--- a/ros2_unitree_legged_msgs/CMakeLists.txt
+++ b/ros2_unitree_legged_msgs/CMakeLists.txt
@@ -16,7 +16,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MotorCmd.msg"

--- a/src/ros2_control_via_keyboard.cpp
+++ b/src/ros2_control_via_keyboard.cpp
@@ -1,0 +1,113 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include <termios.h>
+#include <unistd.h>
+
+using Twist = geometry_msgs::msg::Twist;
+
+int getch()
+{
+	int ch;
+	struct termios oldt;
+	struct termios newt;
+
+	// Store old settings, and copy to new settings
+	tcgetattr(STDIN_FILENO, &oldt);
+	newt = oldt;
+
+	// Make required changes and apply the settings
+	newt.c_lflag &= ~(ICANON | ECHO);
+	newt.c_iflag |= IGNBRK;
+	newt.c_iflag &= ~(INLCR | ICRNL | IXON | IXOFF);
+	newt.c_lflag &= ~(ICANON | ECHO | ECHOK | ECHOE | ECHONL | ISIG | IEXTEN);
+	newt.c_cc[VMIN] = 0;
+	newt.c_cc[VTIME] = 1;
+	tcsetattr(fileno(stdin), TCSANOW, &newt);
+
+	// Get the current character
+	ch = getchar();
+
+	// Reapply old settings
+	tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+
+	return ch;
+}
+
+int main(int argc, char **argv)
+{
+        rclcpp::init(argc, argv);
+        auto node = rclcpp::Node::make_shared("keyboard_input_node");
+        rclcpp::Publisher<Twist>::SharedPtr pub;
+        rclcpp::Rate loop_rate(500);
+
+        pub = node->create_publisher<Twist>("cmd_vel", 1);
+
+	Twist twist;
+
+	long count = 0;
+
+	while (rclcpp::ok())
+	{
+		twist.linear.x = 0.0;
+		twist.linear.y = 0.0;
+		twist.linear.z = 0.0;
+		twist.angular.x = 0.0;
+		twist.angular.y = 0.0;
+		twist.angular.z = 0.0;
+
+		int ch = 0;
+
+		ch = getch();
+
+		printf("%ld\n", count++);
+		printf("ch = %d\n\n", ch);
+
+		switch (ch)
+		{
+		case 'q':
+			printf("already quit!\n");
+			return 0;
+
+		case 'w':
+			twist.linear.x = 0.5;
+			printf("move forward!\n");
+			break;
+
+		case 's':
+			twist.linear.x = -0.5;
+			printf("move backward!\n");
+			break;
+
+		case 'a':
+			twist.linear.y = 0.5;
+			printf("move left!\n");
+			break;
+
+		case 'd':
+			twist.linear.y = -0.5;
+			printf("move right!\n");
+			break;
+
+		case 'j':
+			twist.angular.z = 1.0;
+			printf("turn left!\n");
+			break;
+
+		case 'l':
+			twist.angular.z = -1.0;
+			printf("turn right!\n");
+			break;
+
+		default:
+			printf("Stop!\n");
+			break;
+		}
+
+		pub->publish(twist);
+
+		rclcpp::spin_some(node);
+		loop_rate.sleep();
+	}
+
+	return 0;
+}

--- a/src/ros2_twist_sub.cpp
+++ b/src/ros2_twist_sub.cpp
@@ -7,6 +7,8 @@
 #include "convert.h"
 #include "geometry_msgs/msg/twist.hpp"
 
+using Twist = geometry_msgs::msg::Twist;
+
 using namespace UNITREE_LEGGED_SDK;
 class Custom
 {
@@ -38,7 +40,7 @@ rclcpp::Subscription<ros2_unitree_legged_msgs::msg::LowCmd>::SharedPtr sub_low;
 rclcpp::Publisher<ros2_unitree_legged_msgs::msg::HighState>::SharedPtr pub_high;
 rclcpp::Publisher<ros2_unitree_legged_msgs::msg::LowState>::SharedPtr pub_low;
 
-rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_vel;
+rclcpp::Subscription<Twist>::SharedPtr sub_cmd_vel;
 
 long high_count = 0;
 long low_count = 0;
@@ -87,7 +89,7 @@ void lowCmdCallback(const ros2_unitree_legged_msgs::msg::LowCmd::SharedPtr msg)
     printf("lowCmdCallback ending!\t%ld\n\n", ::low_count++);
 }
 
-void cmdVelCallback(const geometry_msgs::msg::Twist::ConstPtr msg)
+void cmdVelCallback(const Twist::SharedPtr msg)
 {
     printf("cmdVelCallback is running!\t%ld\n", cmd_vel_count);
 
@@ -112,8 +114,7 @@ int main(int argc, char **argv)
     rclcpp::init(argc, argv);
 
     auto node = rclcpp::Node::make_shared("node_ros2_twist_sub");
-
-    sub_cmd_vel = node->create_subscription<geometry_msgs::msg::Twist>("cmd_vel", 1, cmdVelCallback);
+    sub_cmd_vel = node->create_subscription<Twist>("cmd_vel", 1, cmdVelCallback);
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)
     {

--- a/src/ros2_twist_sub.cpp
+++ b/src/ros2_twist_sub.cpp
@@ -88,17 +88,16 @@ void lowCmdCallback(const ros2_unitree_legged_msgs::msg::LowCmd::SharedPtr msg)
 }
 
 void cmdVelCallback(const geometry_msgs::msg::Twist::ConstPtr msg)
-//void cmdVelCallback()
 {
     printf("cmdVelCallback is running!\t%ld\n", cmd_vel_count);
 
     custom.high_cmd = rosMsg2Cmd(msg);
 
-/*
+
     printf("cmd_x_vel = %f\n", custom.high_cmd.velocity[0]);
     printf("cmd_y_vel = %f\n", custom.high_cmd.velocity[1]);
     printf("cmd_yaw_vel = %f\n", custom.high_cmd.yawSpeed);
-*/
+
     ros2_unitree_legged_msgs::msg::HighState high_state_ros;
 
     high_state_ros = state2rosMsg(custom.high_state);

--- a/src/ros2_twist_sub.cpp
+++ b/src/ros2_twist_sub.cpp
@@ -1,0 +1,146 @@
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_unitree_legged_msgs/msg/high_cmd.hpp"
+#include "ros2_unitree_legged_msgs/msg/high_state.hpp"
+#include "ros2_unitree_legged_msgs/msg/low_cmd.hpp"
+#include "ros2_unitree_legged_msgs/msg/low_state.hpp"
+#include "unitree_legged_sdk/unitree_legged_sdk.h"
+#include "convert.h"
+#include "geometry_msgs/msg/twist.hpp"
+
+using namespace UNITREE_LEGGED_SDK;
+class Custom
+{
+public:
+    UDP low_udp;
+    UDP high_udp;
+
+    HighCmd high_cmd = {0};
+    HighState high_state = {0};
+
+    LowCmd low_cmd = {0};
+    LowState low_state = {0};
+
+public:
+    Custom()
+        : low_udp(LOWLEVEL),
+          high_udp(8090, "192.168.12.1", 8082, sizeof(HighCmd), sizeof(HighState))
+    {
+        high_udp.InitCmdData(high_cmd);
+        low_udp.InitCmdData(low_cmd);
+    }
+};
+
+Custom custom;
+
+rclcpp::Subscription<ros2_unitree_legged_msgs::msg::HighCmd>::SharedPtr sub_high;
+rclcpp::Subscription<ros2_unitree_legged_msgs::msg::LowCmd>::SharedPtr sub_low;
+
+rclcpp::Publisher<ros2_unitree_legged_msgs::msg::HighState>::SharedPtr pub_high;
+rclcpp::Publisher<ros2_unitree_legged_msgs::msg::LowState>::SharedPtr pub_low;
+
+rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_vel;
+
+long high_count = 0;
+long low_count = 0;
+long cmd_vel_count = 0;
+
+void highCmdCallback(const ros2_unitree_legged_msgs::msg::HighCmd::SharedPtr msg)
+{
+    printf("highCmdCallback is running !\t%ld\n", ::high_count);
+
+    custom.high_cmd = rosMsg2Cmd(msg);
+
+    custom.high_udp.SetSend(custom.high_cmd);
+    custom.high_udp.Send();
+
+    ros2_unitree_legged_msgs::msg::HighState high_state_ros;
+
+    custom.high_udp.Recv();
+    custom.high_udp.GetRecv(custom.high_state);
+
+    high_state_ros = state2rosMsg(custom.high_state);
+
+    pub_high->publish(high_state_ros);
+
+    printf("highCmdCallback ending !\t%ld\n\n", ::high_count++);
+}
+
+void lowCmdCallback(const ros2_unitree_legged_msgs::msg::LowCmd::SharedPtr msg)
+{
+
+    printf("lowCmdCallback is running !\t%ld\n", low_count);
+
+    custom.low_cmd = rosMsg2Cmd(msg);
+
+    custom.low_udp.SetSend(custom.low_cmd);
+    custom.low_udp.Send();
+
+    ros2_unitree_legged_msgs::msg::LowState low_state_ros;
+
+    custom.low_udp.Recv();
+    custom.low_udp.GetRecv(custom.low_state);
+
+    low_state_ros = state2rosMsg(custom.low_state);
+
+    pub_low->publish(low_state_ros);
+
+    printf("lowCmdCallback ending!\t%ld\n\n", ::low_count++);
+}
+
+void cmdVelCallback(const geometry_msgs::msg::Twist::ConstPtr msg)
+//void cmdVelCallback()
+{
+    printf("cmdVelCallback is running!\t%ld\n", cmd_vel_count);
+
+    custom.high_cmd = rosMsg2Cmd(msg);
+
+/*
+    printf("cmd_x_vel = %f\n", custom.high_cmd.velocity[0]);
+    printf("cmd_y_vel = %f\n", custom.high_cmd.velocity[1]);
+    printf("cmd_yaw_vel = %f\n", custom.high_cmd.yawSpeed);
+*/
+    ros2_unitree_legged_msgs::msg::HighState high_state_ros;
+
+    high_state_ros = state2rosMsg(custom.high_state);
+
+    pub_high->publish(high_state_ros);
+
+    printf("cmdVelCallback ending!\t%ld\n\n", cmd_vel_count++);
+}
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+
+    auto node = rclcpp::Node::make_shared("node_ros2_twist_sub");
+
+//    sub_cmd_vel = node->create_subscription("cmd_vel", 1, cmdVelCallback);
+
+    if (strcasecmp(argv[1], "LOWLEVEL") == 0)
+    {
+        printf("low level runing!\n");
+
+        pub_low = node->create_publisher<ros2_unitree_legged_msgs::msg::LowState>("low_state", 1);
+        sub_low = node->create_subscription<ros2_unitree_legged_msgs::msg::LowCmd>("low_cmd", 1, lowCmdCallback);
+
+        rclcpp::spin(node);
+    }
+    else if (strcasecmp(argv[1], "HIGHLEVEL") == 0)
+    {
+        printf("high level runing!\n");
+
+        pub_high = node->create_publisher<ros2_unitree_legged_msgs::msg::HighState>("high_state", 1);
+        sub_high = node->create_subscription<ros2_unitree_legged_msgs::msg::HighCmd>("high_cmd", 1, highCmdCallback);
+
+        rclcpp::spin(node);
+    }
+    else
+    {
+        std::cout << "Control level name error! Can only be highlevel or lowlevel(not case sensitive)" << std::endl;
+        exit(-1);
+    }
+
+    rclcpp::shutdown();
+
+    return 0;
+}

--- a/src/ros2_twist_sub.cpp
+++ b/src/ros2_twist_sub.cpp
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 
     auto node = rclcpp::Node::make_shared("node_ros2_twist_sub");
 
-//    sub_cmd_vel = node->create_subscription("cmd_vel", 1, cmdVelCallback);
+    sub_cmd_vel = node->create_subscription<geometry_msgs::msg::Twist>("cmd_vel", 1, cmdVelCallback);
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)
     {

--- a/src/ros2_udp.cpp
+++ b/src/ros2_udp.cpp
@@ -22,7 +22,7 @@ public:
 public:
     Custom()
         : low_udp(LOWLEVEL),
-          high_udp(8090, "192.168.123.161", 8082, sizeof(HighCmd), sizeof(HighState))
+          high_udp(8090, "192.168.12.1", 8082, sizeof(HighCmd), sizeof(HighState))
     {
         high_udp.InitCmdData(high_cmd);
         low_udp.InitCmdData(low_cmd);

--- a/src/ros2_walk_example.cpp
+++ b/src/ros2_walk_example.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 
         high_cmd_ros.head[0] = 0xFE;
         high_cmd_ros.head[1] = 0xEF;
-        high_cmd_ros.level_flag = HIGHLEVEL;
+        high_cmd_ros.level_flag = 0;
         high_cmd_ros.mode = 0;
         high_cmd_ros.gait_type = 0;
         high_cmd_ros.speed_level = 0;


### PR DESCRIPTION
For some reason you completely removed the cmd_vel subscribe example. This is the most useful thing in the SDK as far as ROS integration goes, please add this back, and finish fixing the example. I've got one minor thing broken here, but don't have the patience to fix it. 

Oh yeah, I also fixed your broken Geometry / Twist keyboard example... did anyone even bother to test this stuff? I don't know ROS barely at all, and I can tell this was poorly done. What is the deal over there do you need help with ROS as a company in general? 

https://github.com/unitreerobotics/unitree_ros_to_real/issues/50 
